### PR TITLE
fix: FamilyMemberRepositoryのDIコンテナバインディング修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -233,7 +233,7 @@ export default function HomePage() {
                       {activity.description && (
                         <p className="text-sm text-gray-500 mt-1">{activity.description}</p>
                       )}
-                      {activity.checklist.length > 0 && (
+                      {activity.checklist && activity.checklist.length > 0 && (
                         <p className="text-xs text-gray-400 mt-1">
                           チェックリスト: {activity.checklist.filter(item => item.checked).length}/{activity.checklist.length}
                         </p>

--- a/infrastructure/db/family-member-repository.ts
+++ b/infrastructure/db/family-member-repository.ts
@@ -1,0 +1,87 @@
+/**
+ * Dexie.jsを使用したFamilyMemberRepositoryの実装
+ */
+
+import 'reflect-metadata';
+import { injectable } from 'inversify';
+import { Result, ok, err } from 'neverthrow';
+import type { IFamilyMemberRepository, FamilyMemberRepositoryError } from '@/domain/family/repository';
+import type { FamilyMember } from '@/domain/family/types';
+import type { MemberId } from '@/domain/shared/branded-types';
+import { asMemberId, asMemberName, asColor } from '@/domain/shared/branded-types';
+import { db, type FamilyMemberDTO } from './schema';
+
+/**
+ * DTOからドメインモデルへの変換
+ */
+const toDomain = (dto: FamilyMemberDTO): FamilyMember => ({
+  id: asMemberId(dto.id),
+  name: asMemberName(dto.name),
+  avatar: dto.avatar,
+  color: asColor(dto.color)
+});
+
+/**
+ * ドメインモデルからDTOへの変換
+ */
+const toDTO = (domain: FamilyMember): FamilyMemberDTO => ({
+  id: domain.id,
+  name: domain.name,
+  avatar: domain.avatar,
+  color: domain.color
+});
+
+@injectable()
+export class DexieFamilyMemberRepository implements IFamilyMemberRepository {
+  async save(member: FamilyMember): Promise<Result<void, FamilyMemberRepositoryError>> {
+    try {
+      await db.familyMembers.put(toDTO(member));
+      return ok(undefined);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return err({
+        type: 'DatabaseError',
+        message: `家族メンバーの保存に失敗しました: ${errorMessage}`
+      });
+    }
+  }
+
+  async findById(id: MemberId): Promise<Result<FamilyMember | null, FamilyMemberRepositoryError>> {
+    try {
+      const dto = await db.familyMembers.get(id);
+      return ok(dto ? toDomain(dto) : null);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return err({
+        type: 'DatabaseError',
+        message: `家族メンバーの取得に失敗しました: ${errorMessage}`
+      });
+    }
+  }
+
+  async findAll(): Promise<Result<readonly FamilyMember[], FamilyMemberRepositoryError>> {
+    try {
+      const dtos = await db.familyMembers.toArray();
+      return ok(dtos.map(toDomain));
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return err({
+        type: 'DatabaseError',
+        message: `家族メンバー一覧の取得に失敗しました: ${errorMessage}`
+      });
+    }
+  }
+
+  async delete(id: MemberId): Promise<Result<void, FamilyMemberRepositoryError>> {
+    try {
+      await db.familyMembers.delete(id);
+      return ok(undefined);
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return err({
+        type: 'DatabaseError',
+        message: `家族メンバーの削除に失敗しました: ${errorMessage}`
+      });
+    }
+  }
+}

--- a/infrastructure/di/bindings.ts
+++ b/infrastructure/di/bindings.ts
@@ -4,7 +4,7 @@ import type { Container } from 'inversify';
 import { TYPES } from '@/application/shared/types';
 import type { IFamilyMemberRepository } from '@/domain/family/repository';
 import type { ActivityRepository } from '@/domain/activity/repository';
-// import { FamilyMemberRepository } from '@/infrastructure/db/repository'; // 削除済み
+import { DexieFamilyMemberRepository } from '@/infrastructure/db/family-member-repository';
 import { DexieActivityRepository } from '@/infrastructure/db/activity-repository';
 import { FamilyMemberUseCase } from '@/application/family/use-cases';
 import { ActivityUseCase } from '@/application/activity/use-cases';
@@ -12,11 +12,12 @@ import { ActivityUseCase } from '@/application/activity/use-cases';
 /**
  * Infrastructure層でRepositoryを@injectableにする
  */
-// @injectable()
-// class InjectableFamilyMemberRepository extends FamilyMemberRepository {}
 
 @injectable()
 class InjectableActivityRepository extends DexieActivityRepository {}
+
+@injectable()
+class InjectableFamilyMemberRepository extends DexieFamilyMemberRepository {}
 
 /**
  * DIコンテナにバインディングを設定
@@ -24,9 +25,9 @@ class InjectableActivityRepository extends DexieActivityRepository {}
  */
 export const configureContainer = (container: Container): void => {
   // Repository のバインディング
-  // container.bind<IFamilyMemberRepository>(TYPES.IFamilyMemberRepository)
-  //          .to(InjectableFamilyMemberRepository)
-  //          .inSingletonScope();
+  container.bind<IFamilyMemberRepository>(TYPES.IFamilyMemberRepository)
+           .to(InjectableFamilyMemberRepository)
+           .inSingletonScope();
 
   container.bind<ActivityRepository>('ActivityRepository')
            .to(InjectableActivityRepository)


### PR DESCRIPTION
## Summary
- トップページアクセス時の `No bindings found for service: "Symbol(IFamilyMemberRepository)"` エラーを修正
- FamilyMemberRepositoryのDIコンテナバインディングを追加
- DexieFamilyMemberRepositoryの完全実装

## 修正内容
- `InjectableFamilyMemberRepository`クラスを作成
- DIコンテナでFamilyMemberRepositoryを正しくバインド
- DTO↔ドメインモデル変換機能を追加
- Brand型対応のエラーハンドリング修正
- ホームページのnullポインタエラー対策

## Test plan
- [x] 型チェック通過 (`npm run type-check`)
- [x] 開発サーバー正常起動 (`npm run dev`)
- [x] トップページアクセス時のDIエラー解決
- [x] 家族メンバー機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)